### PR TITLE
Make timeline look nicer

### DIFF
--- a/src/components/HorizontalTimelineContent/HorizontalTimelineContent.js
+++ b/src/components/HorizontalTimelineContent/HorizontalTimelineContent.js
@@ -19,7 +19,7 @@ export default class HorizontalTimelineContent extends React.Component {
       minEventPadding: 80,
       maxEventPadding: 80,
       linePadding: 100,
-      labelWidth: 100,
+      labelWidth: 150,
       fillingMotionStiffness: 150,
       fillingMotionDamping: 25,
       slidingMotionStiffness: 150,
@@ -54,7 +54,7 @@ export default class HorizontalTimelineContent extends React.Component {
     });
 
     return (
-      <div>
+      <section className="section">
         <div style={{ width: '60%', height: '100px', margin: '0 auto' }}>
           <HorizontalTimeline
             fillingMotion={{
@@ -96,7 +96,7 @@ export default class HorizontalTimelineContent extends React.Component {
             {views}
           </SwipeableViews>
         </div>
-      </div>
+      </section>
     );
   }
 }

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -15,7 +15,7 @@ class Navbar extends React.Component {
     return (
       <nav className="navbar" role="navigation" aria-label="main navigation">
         <div className="navbar-brand">
-          <a className="navbar-item" href="https://bulma.io">
+          <a className="navbar-item" href="/">
             <img
               src="https://bulma.io/images/bulma-logo.png"
               alt="Bulma: a modern CSS framework based on Flexbox"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,8 +39,7 @@ class IndexPage extends React.Component {
           title="About the Junior Term Abroad Program"
           description="The Junior Term Abroad Program is an opportunity that allows juniors of the Ateneo to study abroad for one semester. Previous participants have described their study-abroad experiences as both academically enriching and personally rewarding, an important period of growth and discovery in their college lives. Participants are expected to be Ateneo's unofficial student-ambassadors, helping build our relationships with our partner institutions abroad."
         />
-        <HorizontalTimelineContent
-          content={this.data} />
+        <HorizontalTimelineContent content={this.data} />
         <div className="section">
           <div className="container">
             <h4 className="title is-4">The Journey</h4>


### PR DESCRIPTION
- Make the content of the timeline be wrapped inside container padding within the section

![image](https://user-images.githubusercontent.com/25378966/42978238-6bf73e4e-8bfe-11e8-964a-428f1c20b2f9.png)

Timeline is still kind of buggy when changing screen size on desktop, but on fresh reload it fixes itself.